### PR TITLE
スワイプ後にスワイプ前のページのタブをタップしてもページが変わらない

### DIFF
--- a/mth/src/main/java/net/yanzm/mth/MaterialTabHost.java
+++ b/mth/src/main/java/net/yanzm/mth/MaterialTabHost.java
@@ -297,7 +297,7 @@ public class MaterialTabHost extends TabHost implements ViewPager.OnPageChangeLi
         if (scrollingState == ViewPager.SCROLL_STATE_IDLE) {
             updateIndicatorPosition(position, 0);
         }
-        tabWidget.setCurrentTab(position);
+        setCurrentTab(position);
     }
 
     @Override


### PR DESCRIPTION
## STEP BY STEP
1. スワイプでタブを一つ移動する(ページAのタブからページBのタブへ移動)
2. スワイプ前のページのタブを押下(ページAのタブを押下)

Pagerでスクロール後に、TabWidgetのsetCurrentTabを呼び出しており、TabHostのpositionが変更されていなかった。
そのため、タブをタップしても前のpositionにいることになっており、ページが変更されなかった。
TabHostのsetCurrentTabを呼び出すことで問題を修正。
